### PR TITLE
In Serverless 3, artifact is now a property of the layer, rather than package

### DIFF
--- a/index.js
+++ b/index.js
@@ -198,7 +198,7 @@ class ServerlessPlugin {
       // https://stackoverflow.com/questions/19965844/lodash-difference-between-extend-assign-and-merge#comment57512843_19966511
       const mergedConfig = _.merge({}, defaultConfig, this.serverless.service.custom.signer, layers[layer].signer);
 
-      const packagePath = (layers[layer].package) ? (layers[layer].package.artifact) : (null)
+      const packagePath = layers[layer].artifact
 
       signerProcesses[layer] = {
         signerConfiguration: mergedConfig,


### PR DESCRIPTION
Thanks for your work upgrading this plugin to be compatible with Serverless framework 3!

I ran into a small issue when using your fork - if you are using serverless-python-requirements to generate a layer with your dependencies, the layer object now has the artifact filename in the artifact attribute, rather than as an attribute of package

Other than that, it works flawlessly!